### PR TITLE
Introduce Clients Section

### DIFF
--- a/.batchfile
+++ b/.batchfile
@@ -6,5 +6,5 @@ https://github.com/owncloud/ocis-glauth;docs;content/extensions/ocis_glauth
 https://github.com/owncloud/ocis-reva;docs;content/extensions/ocis_reva
 https://github.com/owncloud/ocis-phoenix;docs;content/extensions/ocis_phoenix
 https://github.com/owncloud/ocis-thumbnails;docs;content/extensions/ocis_thumbnails
-https://github.com/owncloud/phoenix;docs;content/phoenix
+https://github.com/owncloud/phoenix;docs;content/clients/web
 https://github.com/owncloud/ocis;docs;content/ocis


### PR DESCRIPTION
Phoenix / ocis web as a client should move to a dedicated *Clients* section below the *Extensions* Section. All Clients should then be added there. The difference between ocis-phoenix and phoenix would become clearer.

But I am too stupid to grok how to add a section... HELP!