### PR TITLE
ignore generated adoc files

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,10 @@ pygmentsCodefences: true
 
 disablePathToLower: true
 
+# Ignore generated adoc files
+ignoreFiles:
+  - extensions/_includes/adoc/.*\.adoc$
+
 # Needed for mermaid/katex shortcodes
 markup:
   tableOfContents:


### PR DESCRIPTION
This PR ignores generated adoc files in the ocis docs.