### PR TITLE
remove archived ocis-wopiserver

### DIFF
--- a/.batchfile
+++ b/.batchfile
@@ -3,4 +3,3 @@ https://github.com/owncloud/ocis;docs;content
 https://github.com/owncloud/ocis-hello;docs;content/extensions/ocis_hello
 https://github.com/owncloud/web;docs;content/clients/web
 https://github.com/owncloud/file-picker;docs;content/integration/file_picker
-https://github.com/owncloud/ocis-wopiserver;docs;content/extensions/ocis_wopiserver


### PR DESCRIPTION
ocis-wopiserver was archived and needs to be removed from owncloud.dev
