### PR TITLE
add ocis-php-sdk to clients list on https://owncloud.dev

### DIFF
--- a/.batchfile
+++ b/.batchfile
@@ -3,3 +3,4 @@ https://github.com/owncloud/ocis;docs;content
 https://github.com/owncloud/ocis-hello;docs;content/extensions/ocis_hello
 https://github.com/owncloud/web;docs;content/clients/web
 https://github.com/owncloud/file-picker;docs;content/integration/file_picker
+https://github.com/owncloud/ocis-php-sdk;docs-hugo;content/clients/ocis-php-sdk


### PR DESCRIPTION
the branch `docs-hugo` on https://github.com/owncloud/ocis-php-sdk contains a copy of the README.md and an `_index.md` with an include statement: https://github.com/owncloud/ocis-php-sdk/tree/docs-hugo
I've called the branch `docs-hugo` because `docs` is already used for the [API docs](https://owncloud.dev/ocis-php-sdk/)

If this is correct and works, I will create a CI job to copy the README.md from the main branch to docs-hugo on every merge