### PR TITLE
Add a "purge-content" step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,11 @@ steps:
   commands:
   - make theme
 
+- name: purge-content
+  image: docker.io/owncloudci/alpine
+  commands:
+  - rm -rf content/
+
 - name: sync
   image: quay.io/thegeeklab/git-batch
   commands:


### PR DESCRIPTION
Identified while debugging:

This step is only necessary when running a local `drone exec` command to test build the documentation.
When triggered via CI build steps, the `content/` directory is always empty, but not when you run it locally. There, it may have contents from former runs and the `sync` step does not purge it.