### PR TITLE
Update docs build process and images used

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,8 +28,8 @@ steps:
 - name: build
   # matching images and/or versions in:
   # - the Makefile of this repo
-  # - repo:ocis|web (.drone.star) and
-  # - ocis: cat .bingo/Variables.mk | grep HUGO
+  # - repo web: in .drone.star and
+  # - repo ocis: cat .bingo/Variables.mk | grep HUGO
   image: hugomods/hugo:base-0.129.0
   commands:
   - hugo

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 THEME_VERSION ?= v0.47.0
 HUGO_IMAGE = hugomods/hugo:base-0.129.0
 
-# note that we cannot run docker as plain command. we need to find the exact location first
+# note that we cannot run docker as plain command because make uses sh and the path variable might not have it included.
+# we need to find the exact location first so it is available for all shells
 DOCKER=$(shell command -v docker)
 
 .PHONY: theme


### PR DESCRIPTION
This PR:

* Updates the docker image and version that is used for building the documentation
* Adds two make commands that can be used in repos cloning this one to ease building steps.
The docker images and versions do not need to be maintained there.
(Except such as in `.bingo/Versions.mk` in ocis and `.drone.star` in web)

Note that using more recent hugo image version will break the system, because theming does not match anymore. This will be part of another series of PR's.

Notre that this PR must be merged first before any other PR in related repos gets merged.

I have tested this by running a local `drone exec` and copying the makefile into the docs/hugo folder in web and staring a docs build/serve command successfully. A local hugo installation did not affected the build process because only the container was used.